### PR TITLE
Fix RefreshIndicatorMode.error

### DIFF
--- a/lib/src/pull_to_refresh_notification.dart
+++ b/lib/src/pull_to_refresh_notification.dart
@@ -394,8 +394,10 @@ class PullToRefreshNotificationState extends State<PullToRefreshNotification>
             completer.complete();
             if (success) {
               _dismiss(RefreshIndicatorMode.done);
-            } else
-              _refreshIndicatorMode = RefreshIndicatorMode.error;
+            } else {
+              _dismiss(RefreshIndicatorMode.canceled);
+              // _refreshIndicatorMode = RefreshIndicatorMode.error;
+            }
           }
         });
       }


### PR DESCRIPTION
If I have some tabs, all tabs does not work after first refresh with `_refreshIndicatorMode = RefreshIndicatorMode.error;`